### PR TITLE
Escape agent output sections

### DIFF
--- a/de/agent_linux.asciidoc
+++ b/de/agent_linux.asciidoc
@@ -455,7 +455,7 @@ Bar_Extender /usr/local/bin/check_bar -s -X -w 4:5
 ----
 
 Wenn Sie jetzt den Agenten lokal laufen lassen, finden Sie
-pro Plugin eine neue Sektion mit dem Titel `&lt;&lt;&lt;mrpe&gt;&gt;&gt;`,
+pro Plugin eine neue Sektion mit dem Titel `+<<<mrpe>>>+`,
 welche Name, Exitcode und Ausgabe des Plugins enthält. Das können Sie mit folgendem
 praktischen `grep`-Befehl überprüfen:
 

--- a/de/datasource_programs.asciidoc
+++ b/de/datasource_programs.asciidoc
@@ -52,7 +52,7 @@ Sie das Programm am besten im Verzeichnis `local/bin` an, dann wird
 es immer automatisch ohne Pfadangabe gefunden.
 
 Folgendes erstes minimales Beispiel heißt `myds` und erzeugt einfache
-fiktive Monitoring-Daten. Diese enthalten als einzige Sektion `&lt;&lt;&lt;df&gt;&gt;&gt;`
+fiktive Monitoring-Daten. Diese enthalten als einzige Sektion `+<<<df>>>+`
 mit der Information zu einem einzigen Dateisystem der Größe 100kB und dem Namen `My_Disk`.
 Das Ganze ist ein Shellskript mit drei Zeilen:
 

--- a/de/piggyback.asciidoc
+++ b/de/piggyback.asciidoc
@@ -169,7 +169,7 @@ link:wato_monitoringagents.html[Artikel über die Agenten] vorstellt.
 Neu ist jetzt, dass im Output eine Zeile erlaubt ist, die mit `&lt;&lt;&lt;&lt;`
 beginnt und mit `&gt;&gt;&gt;&gt;` endet. Dazwischen steht ein Hostname. Alle
 weiteren Monitoring-Daten ab dieser Zeile werden dann diesem Host zugeordnet. Hier
-ist ein beispielhafter Auszug, der die Sektion `&lt;&lt;&lt;esx_vsphere_vm&gt;&gt;&gt;`
+ist ein beispielhafter Auszug, der die Sektion `+<<<esx_vsphere_vm>>>+`
 dem Host `316-VM-MGM` zuordnet:
 
 [{file}]

--- a/de/wato_monitoringagents.asciidoc
+++ b/de/wato_monitoringagents.asciidoc
@@ -296,7 +296,7 @@ PluginsDirectory: /usr/lib/check_mk_agent/plugins
 ----
 
 Die Ausgabe beginnt immer mit der Zeile
-`&lt;&lt;&lt;check_mk&gt;&gt;&gt;`. Zeilen, die in
+`+<<<check_mk>>>+`. Zeilen, die in
 `&lt;&lt;&lt;` und `&gt;&gt;&gt;` eingeschlossen sind, werden als
 _Sektionsheader_ bezeichnet. Sie teilen die Agentenausgaben in Sektionen.
 Jede Sektion enthält zusammengehörige Informationen und ist meist einfach die

--- a/en/agent_linux.asciidoc
+++ b/en/agent_linux.asciidoc
@@ -473,7 +473,7 @@ Bar_Extender /usr/local/bin/check_bar -s -X -w 4:5
 
 
 If the agent is allowed to run locally, for each plug-in a new section will be
-found with the title `&lt;&lt;&lt;mrpe&gt;&gt;&gt;`, containing the name,
+found with the title `+<<<mrpe>>>+`, containing the name,
 exit code and output from the the plug-in. This can be verified with the
 following practical `grep`-command:
 

--- a/en/datasource_programs.asciidoc
+++ b/en/datasource_programs.asciidoc
@@ -54,7 +54,7 @@ without the need to specify a data path.
 
 The following first very basic example is called `myds` and it generates
 simple, fictional monitoring data.
-These consist of one section `&lt;&lt;&lt;df&gt;&gt;&gt;`, which contains the
+These consist of one section `+<<<df>>>+`, which contains the
 information for a single file system, and which has a size of 100kB and the name `My_Disk`.
 It is coded as a shell script of three lines:
 

--- a/en/piggyback.asciidoc
+++ b/en/piggyback.asciidoc
@@ -171,7 +171,7 @@ What’s new is that a line is allowed in the output that starts with
 In between is a hostname. All further monitoring data starting from this line is
 then assigned to this host.
 Here is an example excerpt that assigns the section
-`&lt;&lt;&lt;esx_vsphere_vm&gt;&gt;&gt;` to the host `316-VM-MGM`:
+`+<<<esx_vsphere_vm>>>+` to the host `316-VM-MGM`:
 
 [{file}]
 ----

--- a/en/wato_monitoringagents.asciidoc
+++ b/en/wato_monitoringagents.asciidoc
@@ -291,7 +291,7 @@ PluginsDirectory: /usr/lib/check_mk_agent/plugins
 ----
 
 The output always begins with the line
-`&lt;&lt;&lt;check_mk&gt;&gt;&gt;`. Lines included in
+`+<<<check_mk>>>+`. Lines included in
 `&lt;&lt;&lt;` and `&gt;&gt;&gt;` are called _Section
 Headers_. These divide the agent output into sections.  Each section
 contains related information and is usually simply the output from a diagnosis


### PR DESCRIPTION
Otherwise they are handled as cross references

Should this be ported to 2.0.0 and 1.6.0, too?