### PR TITLE
Remove Galera cluster checks from 1.6.0 documentation

### DIFF
--- a/de/monitoring_mysql.asciidoc
+++ b/de/monitoring_mysql.asciidoc
@@ -13,17 +13,12 @@ link:check_plugins_catalog.html[Katalog der Checkplugins]
 
 == Einleitung
 
-{CMK} erlaubt Ihnen die umfangreiche Überwachung von MySQL und Galera Cluster
-für MySQL. Eine vollständige Liste der Überwachungsmöglichkeiten können
+{CMK} erlaubt Ihnen die umfangreiche Überwachung von MySQL.
+Eine vollständige Liste der Überwachungsmöglichkeiten können
 Sie in unserem link:https://checkmk.de/cms_check_plugins_catalog.html#Applications[Katalog der Check-Plugins]
 nachlesen. Unter anderem kann {CMK} die folgenden Werte überwachen:
 
 * link:https://checkmk.de/cms_check_mysql_sessions.html[ MySQL Database sessions]
-* link:https://checkmk.de/cms_check_mysql_galeradonor.html[ MySQL Database: Galera Donor]
-* link:https://checkmk.de/cms_check_mysql_galerasize.html[ MySQL Database: Galera Size]
-* link:https://checkmk.de/cms_check_mysql_galerastartup.html[ MySQL Database: Galera Startup]
-* link:https://checkmk.de/cms_check_mysql_galerastatus.html[ MySQL Database: Galera Status]
-* link:https://checkmk.de/cms_check_mysql_galerasync.html[ MySQL Database: Galera Sync Status]
 * link:https://checkmk.de/cms_check_mysql_connections.html[ MySQL Maximum connection usage since startup]
 * link:https://checkmk.de/cms_check_mysql_slave.html[ MySQL Database: Slave Sync Status]
 * link:https://checkmk.de/cms_check_mysql_ping.html[ MySQL Deamon: Status]

--- a/en/monitoring_mysql.asciidoc
+++ b/en/monitoring_mysql.asciidoc
@@ -12,17 +12,12 @@ link:check_plugins_catalog.html[Catalog of Check Plug-ins]
 
 == Introduction
 
-{CMK} allows you to comprehensively monitor MySQL and Galera clusters for MySQL.
+{CMK} allows you to comprehensively monitor MySQL.
 You can find a complete list of monitoring options in our
 link:https://checkmk.com/cms_check_plugins_catalog.html#Applications[Catalogue of Check Plug-ins].
 Among other things, {CMK} can monitor the following:
 
 * link:https://checkmk.com/cms_check_mysql_sessions.html[ MySQL Database sessions]
-* link:https://checkmk.com/cms_check_mysql_galeradonor.html[ MySQL Database: Galera Donor]
-* link:https://checkmk.com/cms_check_mysql_galerasize.html[ MySQL Database: Galera Size]
-* link:https://checkmk.com/cms_check_mysql_galerastartup.html[ MySQL Database: Galera Startup]
-* link:https://checkmk.com/cms_check_mysql_galerastatus.html[ MySQL Database: Galera Status]
-* link:https://checkmk.com/cms_check_mysql_galerasync.html[ MySQL Database: Galera Sync Status]
 * link:https://checkmk.com/cms_check_mysql_connections.html[ MySQL Maximum connection usage since startup]
 * link:https://checkmk.com/cms_check_mysql_slave.html[ MySQL Database: Slave Sync Status]
 * link:https://checkmk.com/cms_check_mysql_ping.html[ MySQL Deamon: Status]


### PR DESCRIPTION
These checks have been introduced with Checkmk 2.0, so they should not be mentioned in the documentation for 1.6.