### PR TITLE
fix typo in devel_check_plugins

### DIFF
--- a/de/devel_check_plugins.asciidoc
+++ b/de/devel_check_plugins.asciidoc
@@ -536,7 +536,7 @@ register.check_plugin(
 ----
 
 Versuchen Sie am besten noch nicht, das gleich auszuprobieren, denn natürlich
-müssen wir die Funktionen `discovery_linux_usbstick` und `check_linux_usbstick`
+müssen wir die Funktionen `discover_linux_usbstick` und `check_linux_usbstick`
 vorher noch schreiben. Und diese müssen im Quellcode _vor_ obiger Deklaration
 erscheinen.
 
@@ -568,7 +568,7 @@ benötigt man keine weitere Angaben:
 
 [{file}]
 ----
-def discovery_linux_usbstick(section):
+def discover_linux_usbstick(section):
     yield Service()
 ----
 

--- a/en/devel_check_plugins.asciidoc
+++ b/en/devel_check_plugins.asciidoc
@@ -531,7 +531,7 @@ register.check_plugin(
 ----
 
 It's best not to try this out just yet, because of course we still have to write
-the `discovery_linux_usbstick` and `check_linux_usbstick` functions
+the `discover_linux_usbstick` and `check_linux_usbstick` functions
 beforehand, and these functions must appear in the source code _before_
 the above declaration.
 
@@ -561,7 +561,7 @@ For checks that can only occur once per host, no further information is needed:
 
 [{file}]
 ----
-def discovery_linux_usbstick(section):
+def discover_linux_usbstick(section):
     yield Service()
 ----
 


### PR DESCRIPTION
Changes two occurrences of discovery_linux_usbstick to match the three
occurrences of "discover_linux_usbstick" used later in the same
documents.

Thanks creating for checkmk!