### PR TITLE
Update info on supported Debian versions

### DIFF
--- a/en/install_packages.asciidoc
+++ b/en/install_packages.asciidoc
@@ -56,7 +56,7 @@ We currently support the following Linux distributions:
 
 * Red Hat Enterprise Linux (RHEL) and CentOS from Version 7.x
 * SUSE Linux Enterprise Server (SLES) from Version 12 SP3
-* Debian from Version 9.0
+* Debian Version 9.0 and 10.0
 * Ubuntu Version 16.04, 18.04 and from Version 20.04
 
 For {CMK} the installation you need a physical or virtual server on which you


### PR DESCRIPTION
Since Checkmk doesn't support Debian 11 yet, it might be helpful to mention what are the specific supported versions.