### PR TITLE
Update draft_saml.asciidoc

### DIFF
--- a/de/draft_saml.asciidoc
+++ b/de/draft_saml.asciidoc
@@ -112,17 +112,16 @@ Define SITE mysite
 # to generate the needed URLs in the metadata
 ServerName https://myserver
 
-# Load the module from the systems Apache location as we don't ship auth_mellon within OMD yet.
 <IfModule !mod_auth_mellon.c>
 
 	# Debian based systems:
-	LoadModule auth_mellon_module /omd/sites/mysite/lib/apache/modules/mod_auth_mellon.so
+	LoadModule auth_mellon_module /omd/sites/${SITE}/lib/apache/modules/mod_auth_mellon.so
 	
-	# Use this line on  CentOS 7/8
+	# Use this line on CentOS 7/8
 	#LoadModule auth_mellon_module /usr/lib64/httpd/modules/mod_auth_mellon.so
 
 	# When using CentOS 7/8 and in need of diagnostics install mod_auth_mellon-diagnostics package, and use the following statement:
-	LoadModule auth_mellon_module /usr/lib64/httpd/modules/mod_auth_mellon-diagnostics.so
+	#LoadModule auth_mellon_module /usr/lib64/httpd/modules/mod_auth_mellon-diagnostics.so
 
 </IfModule>
 
@@ -141,8 +140,7 @@ ServerName https://myserver
 		! %{REQUEST_URI} = '/${SITE}/check_mk/webapi.py' && \
 		! %{REQUEST_URI} -strmatch '/${SITE}/check_mk/api/*' && \
 		! %{QUERY_STRING} =~ /(_secret=|auth_|register_agent)/ && \
-		! %{REQUEST_URI} =~ m#^/${SITE}/(omd/|check_mk/(images/.*\.png|login\.py|.*\.(css|js)))# ">
-		! %{REQUEST_URI} =~ m#^/${SITE}/(omd/|check_mk/(images/.*\.svg|login\.py|.*\.(css|js)))# ">
+		! %{REQUEST_URI} =~ m#^/${SITE}/(omd/|check_mk/((images|themes)/.*\.(png|svg)|login\.py|.*\.(css|js)))# ">
 		
 		MellonIdPMetadataFile /opt/omd/sites/${SITE}/etc/apache/mellon/idp-metadata.xml
 		MellonIdPPublicKeyFile /opt/omd/sites/${SITE}/etc/apache/mellon/idp-public-key.pem
@@ -192,7 +190,7 @@ Zu guter letzt laden Sie nun die dynamisch erstellten Mellon-Metadaten als XML-D
 
 [{shell}]
 ----
-OMD[mysite]:~/etc/apache/mellon$ wget https://myserver/mysite/mellon/metadata -o metadata.xml
+OMD[mysite]:~/etc/apache/mellon$ wget https://myserver/mysite/mellon/metadata -O metadata.xml
 ----
 
 == Active Directory konfigurieren
@@ -293,13 +291,13 @@ ServerName https://myserver
 <IfModule !mod_auth_mellon.c>
 
 	# Debian based systems:
-	#LoadModule auth_mellon_module /usr/lib/apache2/modules/mod_auth_mellon.so
+	LoadModule auth_mellon_module /omd/sites/${SITE}/lib/apache/modules/mod_auth_mellon.so
 	
 	# Use this line on CentOS 7/8
 	#LoadModule auth_mellon_module /usr/lib64/httpd/modules/mod_auth_mellon.so
 
 	# When using CentOS 7/8 and in need of diagnostics install mod_auth_mellon-diagnostics package, and use the following statement:
-	LoadModule auth_mellon_module /usr/lib64/httpd/modules/mod_auth_mellon-diagnostics.so
+	#LoadModule auth_mellon_module /usr/lib64/httpd/modules/mod_auth_mellon-diagnostics.so
 
 </IfModule>
 
@@ -318,8 +316,7 @@ ServerName https://myserver
         ! %{REQUEST_URI} -strmatch '/${SITE}/check_mk/api/*' && \
         ! %{REQUEST_URI} = '/${SITE}/check_mk/deploy_agent.py' && \
         ! %{QUERY_STRING} =~ /(_secret=|auth_|register_agent)/ && \
-        ! %{REQUEST_URI} =~ m#^/${SITE}/(omd/|check_mk/(images/.*\.png|login\.py|.*\.(css|js)))# ">
-        ! %{REQUEST_URI} =~ m#^/${SITE}/(omd/|check_mk/(images/.*\.svg|login\.py|.*\.(css|js)))# ">
+        ! %{REQUEST_URI} =~ m#^/${SITE}/(omd/|check_mk/((images|themes)/.*\.(png|svg)|login\.py|.*\.(css|js)))# ">
 
         RequestHeader unset X-Remote-User
         MellonIdPMetadataFile /opt/omd/sites/${SITE}/etc/apache/mellon/idp-metadata.xml
@@ -380,13 +377,13 @@ ServerName https://myserver.mydomain.tld
 <IfModule !mod_auth_mellon.c>
 
     # Use this line on Debian based systems.
-    #LoadModule auth_mellon_module /usr/lib/apache2/modules/mod_auth_mellon.so
+    LoadModule auth_mellon_module /omd/sites/${SITE}/lib/apache/modules/mod_auth_mellon.so
 
-    # Use this line on  CentOS 7/8
+    # Use this line on CentOS 7/8
     #LoadModule auth_mellon_module /usr/lib64/httpd/modules/mod_auth_mellon.so
 
     # When using CentOS 7/8 and in need of diagnostics install mod_auth_mellon-diagnostics package, and use the following statement:
-    LoadModule auth_mellon_module /usr/lib64/httpd/modules/mod_auth_mellon-diagnostics.so
+    #LoadModule auth_mellon_module /usr/lib64/httpd/modules/mod_auth_mellon-diagnostics.so
 	
 </IfModule>
 
@@ -406,8 +403,7 @@ ServerName https://myserver.mydomain.tld
         ! %{REQUEST_URI} = '/${SITE}/check_mk/webapi.py' && \
         ! %{REQUEST_URI} -strmatch '/${SITE}/check_mk/api/*' && \
         ! %{QUERY_STRING} =~ /(_secret=|auth_|register_agent)/ && \
-        ! %{REQUEST_URI} =~ m#^/${SITE}/(omd/|check_mk/(images/.*\.png|login\.py|.*\.(css|js)))# ">
-        ! %{REQUEST_URI} =~ m#^/${SITE}/(omd/|check_mk/(images/.*\.svg|login\.py|.*\.(css|js)))# ">
+        ! %{REQUEST_URI} =~ m#^/${SITE}/(omd/|check_mk/((images|themes)/.*\.(png|svg)|login\.py|.*\.(css|js)))# ">
 
         MellonIdPMetadataFile /opt/omd/sites/${SITE}/etc/apache/mellon/idp-metadata.xml
         # NetIQ-specific: Not needed because in metadata:


### PR DESCRIPTION
I had to introduce some slight changes to the draft version of the SAML authentication documentation to get it working.

- Fixes a non-working wget (`-o` writes a log).
- Fixes syntax error in example apache configuration
      (If-directive has two closing brackets)

Please feel free to contact me for questions or further testing.