### PR TITLE
fix path to active check

### DIFF
--- a/en/active_checks.asciidoc
+++ b/en/active_checks.asciidoc
@@ -157,7 +157,7 @@ the status. This must be 0 for {OK}, 1 for {WARN}, 2 for {CRIT} or 3 for
 {UNKNOWN}. A short example to illustrate the very simple to understand syntax
 can be found here:
 
-./omd/sites/mysite/myscript.sh
+./omd/sites/mysite/tmp/myscript.sh
 [{file}]
 ----
 #!/bin/bash


### PR DESCRIPTION
The file box displayed `$SITE/myscript.sh` as the path to the script
but the install command used `$SITE/tmp/myscript.sh`.

This fix makes the path consistently `$SITE/tmp/myscript.sh`.