### PR TITLE
Fixed wget parameter

### DIFF
--- a/de/monitoring_jobs.asciidoc
+++ b/de/monitoring_jobs.asciidoc
@@ -35,7 +35,7 @@ Dabei ist es die einfachste Methode, das Programm mit `wget` direkt von Ihrem {C
 
 [{shell-raw}]
 ----
-{c-root} wget -o /usr/local/bin/mk-job https://myserver/mysite/check_mk/agents/mk-job
+{c-root} wget -O /usr/local/bin/mk-job https://myserver/mysite/check_mk/agents/mk-job
 {c-root} chmod +x /usr/local/bin/mk-job
 ----
 

--- a/en/monitoring_jobs.asciidoc
+++ b/en/monitoring_jobs.asciidoc
@@ -35,7 +35,7 @@ The easiest way to do this is to fetch the programme directly from your {CMK} se
 
 [{shell-raw}]
 ----
-{c-root} wget -o /usr/local/bin/mk-job https://myserver/mysite/check_mk/agents/mk-job
+{c-root} wget -O /usr/local/bin/mk-job https://myserver/mysite/check_mk/agents/mk-job
 {c-root} chmod +x /usr/local/bin/mk-job
 ----
 


### PR DESCRIPTION
wget needs "-O" (big o) as a parameter to redirect the output to a specific file. Using "-o" (small o) just redirects the program output of wget, which is not what we want in this case. See: https://linux.die.net/man/1/wget