### PR TITLE
Remove update to lower version hint

### DIFF
--- a/en/omd_basics.asciidoc
+++ b/en/omd_basics.asciidoc
@@ -22,7 +22,7 @@ An OMD-based installation is distinguished by a number of characteristics:
 
 * the ability to run _multiple_ monitoring sites in parallel
 * the ability to operate sites with _differing versions_ of the monitoring software
-* an intelligent and convenient mechanism for updating the software - to a higher and lower version,
+* an intelligent and convenient mechanism for updating the software
 * an intelligent and easy to operate upgrade/downgrade-mechanism
 * uniform file paths -- regardless of which Linux-platform is installed
 * a clear separation of _data_ and _software_


### PR DESCRIPTION
Updating to lower versions is not recommended, thus shouldn't be mentioned in the docs.