### PR TITLE
Adapt to new grafana plugin package

### DIFF
--- a/de/grafana.asciidoc
+++ b/de/grafana.asciidoc
@@ -37,34 +37,26 @@ Ist diese Prüfung abgeschlossen, wird die Installation direkt aus der Grafana-O
 
 === Plugin installieren
 
-Um das Plugin benutzen zu können, haben Sie zwei Möglichkeiten, es Grafana bekannt zu machen:
 
-* Sie laden die ZIP-Datei aus dem link:https://github.com/tribe29/grafana-checkmk-datasource[GitHub-Repository^] herunter und legen die Inhalte manuell in das Plugin-Verzeichnis von Grafana.
-* Sie klonen das GitHub-Projekt direkt in das Plugin-Verzeichnis.
-
-
-==== Installation der ZIP-Datei
-
-Dieser Variante ist die einfachste und dann zu bevorzugen, wenn Sie `git` auf dem Grafana-Server nicht installiert haben und dies auch nicht können/wollen.
-Laden Sie einfach die aktuellste Version als ZIP-Datei herunter und kopieren Sie diese, z.B. mit `scp`, auf den Grafana-Server:
+Laden Sie einfach die link:https://github.com/tribe29/grafana-checkmk-datasource/releases[aktuellste Version] als Zip-Datei herunter
+und kopieren Sie sie, z.B. mit `scp`, auf den Grafana-Server.
 
 [{image-border}]
 image::grafana_download_plugin.png[]
 
-Alternativ können Sie die Datei natürlich auch direkt über die Kommandozeile laden.
-Beachten Sie, dass Sie dafür die korrekte Version wissen müssen.
-In folgendem Befehl wird der Dateiname, so wie er lokal gespeichert werden soll, mit der `wget`-Option `-O` festgelegt, da die Datei sonst einfach `2.0b2.zip` heißen würde:
+Alternativ können Sie die Datei natürlich auch direkt über die Kommandozeile
+laden. Beachten Sie, dass Sie dafür die korrekte Version wissen müssen.
 
 [{shell-raw}]
 ----
-{c-root} wget -O grafana-checkmk-datasource-2.0b2.zip https://github.com/tribe29/grafana-checkmk-datasource/archive/refs/tags/2.0b2.zip
+{c-root} wget https://github.com/tribe29/grafana-checkmk-datasource/releases/download/v2.0.2/tribe-29-checkmk-datasource-2.0.2.zip
 ----
 
 Entpacken Sie jetzt das Zip-Archiv:
 
 [{shell}]
 ----
-{c-root} unzip grafana-checkmk-datasource-2.0b2.zip
+{c-root} unzip tribe-29-checkmk-datasource-2.0.2.zip
 ----
 
 Verschieben Sie den entstandenen Ordner in das Plugin-Verzeichnis von Grafana.
@@ -72,83 +64,17 @@ Verschieben Sie den entstandenen Ordner in das Plugin-Verzeichnis von Grafana.
 
 [{shell}]
 ----
-{c-root} mv -v grafana-checkmk-datasource-2.0b2 /var/lib/grafana/plugins/grafana-checkmk-datasource
+{c-root} mv -v tribe-29-checkmk-datasource /var/lib/grafana/plugins/tribe-29-checkmk-datasource
 ----
 
 Ändern Sie den Eigentümer auf den Grafana-Nutzer (meist `grafana`):
 
 [{shell}]
 ----
-{c-root} chown -R grafana:grafana /var/lib/grafana/plugins/grafana-checkmk-datasource
+{c-root} chown -R grafana:grafana /var/lib/grafana/plugins/tribe-29-checkmk-datasource
 ----
 
-Anschließend fahren Sie mit der xref:allow_unsigned[Anpassung der Berechtigungen] fort.
-
-
-==== Installation über das Klonen des Git-Archivs
-
-Die oben beschriebene Variante hat die wenigsten Voraussetzungen und ist auch für weniger versierte Nutzer leicht umsetzbar.
-Falls Sie aber das Plugin direkt aus dem Git-Repository beziehen, haben Sie dadurch verschiedene Vorteile:
-
-* Die Aktualisierung auf eine neue Version geht schnell über diesen Befehl: `git pull`
-* Sie haben die Möglichkeit, direkt den aktuellen Entwicklungsstand aus dem Archiv zu nutzen, wenn Sie ein neues Features testen wollen: `git checkout develop`
-
-Um das Plugin mit Hilfe einer Kopie des Archivs zu nutzen, benötigen Sie zwingend das Programm `git`.
-Das Vorgehen ist danach recht einfach.
-Wechseln Sie zunächst in das Plugin-Verzeichnis von Grafana, klonen Sie dort das Git-Repository:
-
-// MA: Ob wir hier voraussetzen können, dass man sich bereits im Pluginverzeichnis
-// MA: befindet? Das würde den Befehl einfacher machen. Vor allem auch, weil Du
-// MA: Dich danach auf diesen Pfad auch weiterhin beziehst.
-// MFS: Schwierig, zwischendurch mal ne Shell zugemacht o.ä. …
-// MFS: Auch hier zwei Prompts
-// MA: Ich hab eher an so etwas gedacht. Mit einem Hinweis auf den Pfad:
-////
-----
-root@linux:/var/lib/grafana/plugins# git clone https://github.com/tribe29/grafana-checkmk-datasource.git
-Cloning into 'grafana-checkmk-datasource'...
-remote: Enumerating objects: 541, done.
-remote: Total 541 (delta 0), reused 0 (delta 0), pack-reused 541
-Receiving objects: 100% (541/541), 291.55 KiB | 0 bytes/s, done.
-Resolving deltas: 100% (374/374), done.
-Checking connectivity... done.
-----
-////
-
-[{shell-raw}]
-----
-{c-root} cd /var/lib/grafana/plugins && git clone https://github.com/tribe29/grafana-checkmk-datasource.git
-Cloning into 'grafana-checkmk-datasource'...
-remote: Enumerating objects: 541, done.
-remote: Total 541 (delta 0), reused 0 (delta 0), pack-reused 541
-Receiving objects: 100% (541/541), 291.55 KiB | 0 bytes/s, done.
-Resolving deltas: 100% (374/374), done.
-Checking connectivity... done.
-----
-
-Da der Main-Branch immer die aktuellste Version abbildet, brauchen Sie nach einer neuen Veröffentlichung lediglich folgenden Befehl auszuführen, um das Plugin auf dem Grafana-Server zu aktualisieren:
-
-[{shell}]
-----
-{c-root} cd /var/lib/grafana/plugins/grafana-checkmk-datasource && git pull
-----
-
-Bei der Verwendung des Development Trees fehlen noch einige notwendige Dateien und Verzeichnisse, um das Plugin in Grafana nutzen zu können.
-So ist das Plugin in Typescript programmiert, welches nicht direkt interpretiert werden kann, sondern vorher nach JavaScript kompiliert werden muss.
-Über folgendes Kommando erledigt das Programm `yarn` das Bauen der fehlenden Dateien für Sie:
-
-[{shell}]
-----
-{c-root} cd /var/lib/grafana/plugins/grafana-checkmk-datasource && yarn run build
-----
-// MA: Entweder mit && verknüpfen, oder den Pfad im Prompt hinterlegen, oder zwei prompts rausschreiben. Hauptsache es ist einheitlich über den gesamten Artikel hinweg.
-
-Korrigieren Sie wie oben gezeigt nach jeder Änderung des Plugins die Eigentümerschaft:
-
-[{shell}]
-----
-{c-root} chown -R grafana:grafana /var/lib/grafana/plugins/grafana-checkmk-datasource
-----
+_Installation über das Klonen des Git-Archivs_ (wie es zuvor in diesem Dokument beschrieben wurde) ist nicht mehr möglich.
 
 
 [#allow_unsigned]

--- a/en/grafana.asciidoc
+++ b/en/grafana.asciidoc
@@ -36,34 +36,25 @@ Once this review has been completed, an installation directly from the Grafana u
 
 === Installing the plug-ins
 
-To be able to use the plug-in, follow one of these two procedures to add it into Grafana:
-
-* Download the ZIP file from the link:https://github.com/tribe29/grafana-checkmk-datasource[GitHub project^], and manually move the content into the Grafana plug-in directory.
-* Clone the GitHub project directly into the plug-in directory.
-
-
-==== Installation from the ZIP file
-
-This variant is the simplest and thus preferred way if you have not installed `git` on the Grafana server and cannot/do not want to.
-To install the plug-in, simply download the ZIP file with the latest version, and copy it -- for example, with `scp` -- to the Grafana server:
+To install the plug-in, simply download the link:https://github.com/tribe29/grafana-checkmk-datasource/releases[zip file] with the latest version, and copy
+it – for example, with `scp` – to the Grafana server.
 
 [{image-border}]
 image::grafana_download_plugin.png[]
 
 Alternatively, you can also load the file directly from the command line.
 Note that you need to know the correct version for this.
-With the option `-O` in the following command, the name of the local file is specified manually, since otherwise it would be `2.0b2.zip`:
 
 [{shell-raw}]
 ----
-{c-root} wget -O grafana-checkmk-datasource-2.0b2.zip https://github.com/tribe29/grafana-checkmk-datasource/archive/refs/tags/2.0b2.zip
+{c-root} wget https://github.com/tribe29/grafana-checkmk-datasource/releases/download/v2.0.2/tribe-29-checkmk-datasource-2.0.2.zip
 ----
 
 Now unpack the archive:
 
 [{shell}]
 ----
-{c-root} unzip grafana-checkmk-datasource-2.0b2.zip
+{c-root} unzip tribe-29-checkmk-datasource-2.0.2.zip
 ----
 
 Next, move the newly created folder to Grafana's plug-in directory.
@@ -71,58 +62,17 @@ Its path is usually: `/var/lib/grafana/plugins/`
 
 [{shell}]
 ----
-{c-root} mv -v grafana-checkmk-datasource-2.0b2 /var/lib/grafana/plugins/grafana-checkmk-datasource
+{c-root} mv -v tribe-29-checkmk-datasource /var/lib/grafana/plugins/tribe-29-checkmk-datasource
 ----
 
 Change ownership to the Grafana user (typically `grafana`):
 
 [{shell}]
 ----
-{c-root} chown -R grafana:grafana /var/lib/grafana/plugins/grafana-checkmk-datasource
+{c-root} chown -R grafana:grafana /var/lib/grafana/plugins/tribe-29-checkmk-datasource
 ----
 
-When done, continue with the xref:allow_unsigned[definition of permissions].
-
-
-==== Installation by cloning the Git archive
-
-The variant described above has the fewest requirements, and is easy to implement even for less-experienced users.
-But if you get the plug-in directly from the Git repository, there are several advantages:
-
-* Upgrading to a new version can be quickly performed with one command: `git pull`
-* You have the option of using the current development version directly from the archive if you want to test a new feature: `git checkout develop`
-
-To use the plug-in with the help of a copy of the archive, you absolutely need the `git` program.
-The procedure is then quite simple:
-first change the working directory to the Grafana plug-in directory, then clone the repository:
-
-[{shell-raw}]
-----
-{c-root} cd /var/lib/grafana/plugins/ && git clone https://github.com/tribe29/grafana-checkmk-datasource.git
-Cloning into 'grafana-checkmk-datasource'...
-remote: Enumerating objects: 541, done.
-remote: Total 541 (delta 0), reused 0 (delta 0), pack-reused 541
-Receiving objects: 100% (541/541), 291.55 KiB | 0 bytes/s, done.
-Resolving deltas: 100% (374/374), done.
-Checking connectivity... done.
-----
-
-Since the master branch always shows the latest version, following a new release you just need to execute the following command to update the plug-in on the Grafana server:
-
-[{shell}]
-----
-{c-root} cd /var/lib/grafana/plugins/grafana-checkmk-datasource && git pull
-----
-
-When using the development tree, you need to create missing files and directories to be able to actually use the plug-in.
-For example the plug-in is written in the Typescript programming language that cannot be directly interpreted but has to be translated to JavaScript first.
-This is done with the `yarn` tool by running the following command:
-
-[{shell}]
-----
-{c-root} cd /var/lib/grafana/plugins/grafana-checkmk-datasource && yarn run build
-----
-
+_Installation by cloning the Git archive_ (as stated in previous versions of this document) is no longer possible.
 
 [#allow_unsigned]
 === Allowing unsigned plug-ins


### PR DESCRIPTION
We are planning to change the way how to release grafana-checkmk-datasource: https://github.com/tribe29/grafana-checkmk-datasource/pull/75

After this change it won't be possible to use git to deploy the plugin. I tried to address this in this change.

In order to see if everything works I've built a test-package: https://github.com/BenediktSeidl/grafana-checkmk-datasource-testing/releases/tag/v9.9.9

Should I also create a pull request for master?