### PR TITLE
Update agent_freebsd.asciidoc

### DIFF
--- a/en/agent_freebsd.asciidoc
+++ b/en/agent_freebsd.asciidoc
@@ -133,7 +133,7 @@ Now add the following line to the `/etc/inetd.conf` configuration file:
 ./etc/inetd.conf
 [{file}]
 ----
-checkmk-agent stream tcp nowait root /usr/local/bin/check_mk_agent
+checkmk-agent stream tcp nowait root /usr/local/bin/check_mk_agent checkmk-agent
 ----
 
 The `inetd` must always be activated. To do this, append the following line to the `/etc/rc.conf` file:


### PR DESCRIPTION
There was one argument missing in the inetd config. Without this, inetd will error out with the following message
"cannot execute /usr/local/bin/check_mk_agent: Invalid argument"