### PR TITLE
Fixed menu path for LDAP connections setup

### DIFF
--- a/de/ldap.asciidoc
+++ b/de/ldap.asciidoc
@@ -32,7 +32,7 @@ mindestens Lesezugriff auf die Personen und Gruppen haben, welche er
 synchronisieren soll. In den folgenden Beispielen heißt dieser Benutzer
 _check_mk_.
 
-Unter [.guihint]#Setup > Users > LDAP connections > Add connection# können Sie nun eine neue
+Unter [.guihint]#Setup > Users > LDAP & Active Directory > Add connection# können Sie nun eine neue
 Verbindung anlegen. In der Eingabemaske vergeben Sie zunächst eine beliebige
 [.guihint]#ID# für die Verbindung in den [.guihint]#General Properties#. Optional können Sie
 hier unter [.guihint]#Description# einen leicht lesbaren Titel vergeben. Die [.guihint]#ID# muss

--- a/en/ldap.asciidoc
+++ b/en/ldap.asciidoc
@@ -32,7 +32,7 @@ permission for the server. As a minimum it must have read permission for the
 persons and groups that it is to synchronize. In the following example
 this user is called _check_mk_.
 
-Under [.guihint]#Setup > Users > LDAP connections > Add connection# a new connection can be created.
+Under [.guihint]#Setup > Users > LDAP & Active Directory > Add connection# a new connection can be created.
 In the input mask, first enter any desired [.guihint]#ID# for the connection into the
 [.guihint]#General Properties# field. A simple meaningful title can be optionally
 entered in the [.guihint]#Description# field. As always the [.guihint]#ID# must be unique and an


### PR DESCRIPTION
Even though the breadcrumb navigation shows 'LDAP connections' the correct menu path for the user is 'Users > LDAP & Active Directory > Add connection'.