### PR TITLE
Include werk 14794: Dedicated secret token creation

### DIFF
--- a/en/monitoring_kubernetes.asciidoc
+++ b/en/monitoring_kubernetes.asciidoc
@@ -377,7 +377,6 @@ NodePort:
 With the token of the service account named `myrelease-checkmk-checkmk` in the namespace `checkmk-monitoring` you can now issue queries against the `cluster-collector`.
 Run the following to fetch its token and the ca-certificate of the cluster:
   export TOKEN=$(kubectl get secret myrelease-checkmk-checkmk -n checkmk-monitoring -o=jsonpath='{.data.token}' | base64 --decode);
-  export CA_CRT="$(kubectl get secret $(kubectl get serviceaccount myrelease-checkmk-checkmk -o=jsonpath='{.secrets[*].name}' -n checkmk-monitoring) -n checkmk-monitoring -o=jsonpath='{.data.ca\.crt}' | base64 --decode)";
   export CA_CRT="$(kubectl get secret myrelease-checkmk-checkmk -n checkmk-monitoring -o=jsonpath='{.data.ca\.crt}' | base64 --decode)";
 
   # Note: Quote the variable when echo'ing to preserve proper line breaks: `echo "$CA_CRT"`
@@ -406,8 +405,8 @@ When outputting the `CA_CRT` variable, be sure to enclose it in inverted commas,
 
 [{shell}]
 ----
-{c-user} export TOKEN=$(kubectl get secret $(kubectl get serviceaccount myrelease-checkmk-checkmk -o=jsonpath='{.secrets[*].name}' -n checkmk-monitoring) -n checkmk-monitoring -o=jsonpath='{.data.token}' | base64 --decode);
-{c-user} export CA_CRT="$(kubectl get secret $(kubectl get serviceaccount myrelease-checkmk-checkmk -o=jsonpath='{.secrets[*].name}' -n checkmk-monitoring) -n checkmk-monitoring -o=jsonpath='{.data.ca\.crt}' | base64 --decode)";
+{c-user} export TOKEN=$(kubectl get secret myrelease-checkmk-checkmk -n checkmk-monitoring -o=jsonpath='{.data.token}' | base64 --decode);
+{c-user} export CA_CRT="$(kubectl get secret myrelease-checkmk-checkmk -n checkmk-monitoring -o=jsonpath='{.data.ca\.crt}' | base64 --decode)";
 {c-user} echo $TOKEN
 eyJhbGciOiJSUzI1NiIsImtpZCI6InR6VXhGSU ...
 {c-user} echo "$CA_CRT"

--- a/en/monitoring_kubernetes.asciidoc
+++ b/en/monitoring_kubernetes.asciidoc
@@ -376,8 +376,10 @@ NodePort:
   # Cluster-internal DNS of `cluster-collector`: myrelease-checkmk-cluster-collector.checkmk-monitoring
 With the token of the service account named `myrelease-checkmk-checkmk` in the namespace `checkmk-monitoring` you can now issue queries against the `cluster-collector`.
 Run the following to fetch its token and the ca-certificate of the cluster:
-  export TOKEN=$(kubectl get secret $(kubectl get serviceaccount myrelease-checkmk-checkmk -o=jsonpath='{.secrets[*].name}' -n checkmk-monitoring) -n checkmk-monitoring -o=jsonpath='{.data.token}' | base64 --decode);
+  export TOKEN=$(kubectl get secret myrelease-checkmk-checkmk -n checkmk-monitoring -o=jsonpath='{.data.token}' | base64 --decode);
   export CA_CRT="$(kubectl get secret $(kubectl get serviceaccount myrelease-checkmk-checkmk -o=jsonpath='{.secrets[*].name}' -n checkmk-monitoring) -n checkmk-monitoring -o=jsonpath='{.data.ca\.crt}' | base64 --decode)";
+  export CA_CRT="$(kubectl get secret myrelease-checkmk-checkmk -n checkmk-monitoring -o=jsonpath='{.data.ca\.crt}' | base64 --decode)";
+
   # Note: Quote the variable when echo'ing to preserve proper line breaks: `echo "$CA_CRT"`
 To test access you can run:
   curl -H "Authorization: Bearer $TOKEN" \http://$NODE_IP:$NODE_PORT/metadata | jq

--- a/en/monitoring_kubernetes.asciidoc
+++ b/en/monitoring_kubernetes.asciidoc
@@ -378,7 +378,6 @@ With the token of the service account named `myrelease-checkmk-checkmk` in the n
 Run the following to fetch its token and the ca-certificate of the cluster:
   export TOKEN=$(kubectl get secret myrelease-checkmk-checkmk -n checkmk-monitoring -o=jsonpath='{.data.token}' | base64 --decode);
   export CA_CRT="$(kubectl get secret myrelease-checkmk-checkmk -n checkmk-monitoring -o=jsonpath='{.data.ca\.crt}' | base64 --decode)";
-
   # Note: Quote the variable when echo'ing to preserve proper line breaks: `echo "$CA_CRT"`
 To test access you can run:
   curl -H "Authorization: Bearer $TOKEN" \http://$NODE_IP:$NODE_PORT/metadata | jq


### PR DESCRIPTION
Since Kubernetes version 1.24, tokens need to be created differently, thus also retrieving them has changed. See the werk for more info