### PR TITLE
Update omd_basics.asciidoc

### DIFF
--- a/en/omd_basics.asciidoc
+++ b/en/omd_basics.asciidoc
@@ -300,11 +300,11 @@ This can be also performed as `root` if the site's name is added as an argument:
 {c-root} omd config mysite set AUTOSTART off
 ----
 
-The current assignment of all variables can be viewed using `omd config show`:
+The current assignment of all variables can be viewed using `omd config mysite show`:
 
 [{shell}]
 ----
-{c-omd} omd config show
+{c-omd} omd config mysite show
 ADMIN_MAIL: 
 AGENT_RECEIVER: on
 AGENT_RECEIVER_PORT: 8005


### PR DESCRIPTION
Fix site name required in `omd config <mysitename> show` that was missing